### PR TITLE
Scaffold core data models and editor

### DIFF
--- a/Sources/Model/Block.swift
+++ b/Sources/Model/Block.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreData
+
+@objc(Block)
+public class Block: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var noteId: UUID
+    @NSManaged public var type: String
+    @NSManaged public var text: String?
+    @NSManaged public var order: Int16
+    @NSManaged public var style: Data?
+    @NSManaged public var note: Note?
+    @NSManaged public var strokes: NSSet?
+}
+
+extension Block {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Block> {
+        return NSFetchRequest<Block>(entityName: "Block")
+    }
+}

--- a/Sources/Model/Note.swift
+++ b/Sources/Model/Note.swift
@@ -1,0 +1,24 @@
+import Foundation
+import CoreData
+
+@objc(Note)
+public class Note: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var title: String
+    @NSManaged public var createdAt: Date
+    @NSManaged public var updatedAt: Date
+    @NSManaged public var keywords: [String]?
+    @NSManaged public var blocks: NSSet?
+}
+
+extension Note {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Note> {
+        return NSFetchRequest<Note>(entityName: "Note")
+    }
+
+    func blockTexts() -> String {
+        let set = (blocks as? Set<Block>) ?? []
+        let sorted = set.sorted { $0.order < $1.order }
+        return sorted.compactMap { $0.text }.joined(separator: "\n")
+    }
+}

--- a/Sources/Model/Persistence.swift
+++ b/Sources/Model/Persistence.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreData
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "DoneIt")
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+}

--- a/Sources/Model/Stroke.swift
+++ b/Sources/Model/Stroke.swift
@@ -1,0 +1,19 @@
+import Foundation
+import CoreData
+
+@objc(Stroke)
+public class Stroke: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var noteId: UUID
+    @NSManaged public var blockId: UUID
+    @NSManaged public var bbox: String
+    @NSManaged public var archiveURL: URL?
+    @NSManaged public var note: Note?
+    @NSManaged public var block: Block?
+}
+
+extension Stroke {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Stroke> {
+        return NSFetchRequest<Stroke>(entityName: "Stroke")
+    }
+}

--- a/Sources/PersonaUI/Parser.swift
+++ b/Sources/PersonaUI/Parser.swift
@@ -1,0 +1,83 @@
+import Foundation
+import SwiftUI
+
+enum PersonaNode {
+    case page(title: String, children: [PersonaNode])
+    case h1(String)
+    case text(String)
+    case canvas(id: String?, mode: String?)
+    case returnUI(keywords: [String])
+}
+
+struct PersonaParser {
+    func parse(_ input: String) -> PersonaNode? {
+        var children: [PersonaNode] = []
+        var title = ""
+        let lines = input.split(separator: "\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("page") {
+                if let name = extractQuoted(from: trimmed) {
+                    title = name
+                }
+            } else if trimmed.hasPrefix("H1") {
+                if let text = extractQuoted(from: trimmed) {
+                    children.append(.h1(text))
+                }
+            } else if trimmed.hasPrefix("text") {
+                if let text = extractQuoted(from: trimmed) {
+                    children.append(.text(text))
+                }
+            } else if trimmed.hasPrefix("canvas") {
+                let id = extractAttribute("id", from: trimmed)
+                let mode = extractAttribute("mode", from: trimmed)
+                children.append(.canvas(id: id, mode: mode))
+            } else if trimmed.hasPrefix("returnUI") {
+                let keywords = extractKeywords(from: trimmed)
+                children.append(.returnUI(keywords: keywords))
+            }
+        }
+        return .page(title: title, children: children)
+    }
+
+    private func extractQuoted(from line: String) -> String? {
+        guard let range = line.range(of: "\".*?\"", options: .regularExpression) else { return nil }
+        let quoted = line[range]
+        return String(quoted.dropFirst().dropLast())
+    }
+
+    private func extractAttribute(_ name: String, from line: String) -> String? {
+        guard let range = line.range(of: "\(name):\".*?\"", options: .regularExpression) else { return nil }
+        let substring = line[range]
+        return substring.components(separatedBy: "\"")[1]
+    }
+
+    private func extractKeywords(from line: String) -> [String] {
+        guard let start = line.firstIndex(of: "["), let end = line.firstIndex(of: "]") else { return [] }
+        let list = line[line.index(after: start)..<end]
+        return list.split(separator: ",").map { $0.replacingOccurrences(of: "\"", with: "").trimmingCharacters(in: .whitespaces) }
+    }
+}
+
+struct PersonaView: View {
+    let node: PersonaNode
+
+    var body: some View {
+        switch node {
+        case .page(_, let children):
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(Array(children.enumerated()), id: \.offset) { index, child in
+                    PersonaView(node: child)
+                }
+            }
+        case .h1(let text):
+            Text(text).font(.largeTitle)
+        case .text(let text):
+            Text(text)
+        case .canvas:
+            Rectangle().strokeBorder()
+        case .returnUI:
+            EmptyView()
+        }
+    }
+}

--- a/Sources/Services/SaveService.swift
+++ b/Sources/Services/SaveService.swift
@@ -1,0 +1,33 @@
+import Foundation
+import CoreData
+import PencilKit
+
+final class SaveService {
+    private let context: NSManagedObjectContext
+    private let searchIndex: SearchIndex
+
+    init(context: NSManagedObjectContext, searchIndex: SearchIndex) {
+        self.context = context
+        self.searchIndex = searchIndex
+    }
+
+    func save(note: Note, drawing: PKDrawing) {
+        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let fileURL = directory.appendingPathComponent("\(note.id.uuidString).drawing")
+        do {
+            try drawing.dataRepresentation().write(to: fileURL)
+        } catch {
+            print("Failed to save drawing: \(error)")
+        }
+
+        note.updatedAt = Date()
+        do {
+            try context.save()
+            DispatchQueue.global().async {
+                self.searchIndex.index(note: note)
+            }
+        } catch {
+            print("Core Data save failed: \(error)")
+        }
+    }
+}

--- a/Sources/Services/SearchIndex.swift
+++ b/Sources/Services/SearchIndex.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SQLite3
+
+final class SearchIndex {
+    private var db: OpaquePointer?
+
+    init(path: URL) {
+        sqlite3_open(path.path, &db)
+        let createSQL = """
+        CREATE VIRTUAL TABLE IF NOT EXISTS notes USING fts5(id, title, text, keywords);
+        """
+        sqlite3_exec(db, createSQL, nil, nil, nil)
+    }
+
+    deinit {
+        sqlite3_close(db)
+    }
+
+    func index(note: Note) {
+        let insertSQL = "INSERT INTO notes (id, title, text, keywords) VALUES (?, ?, ?, ?);"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, note.id.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, note.title, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 3, note.blockTexts(), -1, SQLITE_TRANSIENT)
+            let keywords = note.keywords?.joined(separator: " ") ?? ""
+            sqlite3_bind_text(stmt, 4, keywords, -1, SQLITE_TRANSIENT)
+            sqlite3_step(stmt)
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    func search(_ query: String) -> [String] {
+        var results: [String] = []
+        let searchSQL = "SELECT snippet(notes, 2, '[', ']', '…', 10) FROM notes WHERE notes MATCH ?;"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, searchSQL, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, query, -1, SQLITE_TRANSIENT)
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                if let cString = sqlite3_column_text(stmt, 0) {
+                    results.append(String(cString: cString))
+                }
+            }
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+}

--- a/Sources/Views/LayeredEditorView.swift
+++ b/Sources/Views/LayeredEditorView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import PencilKit
+
+struct LayeredEditorView: View {
+    @State private var isDrawing = false
+    @State private var text: String = ""
+    @State private var canvasView = PKCanvasView()
+
+    var body: some View {
+        ZStack {
+            CanvasRepresentable(canvasView: $canvasView)
+                .allowsHitTesting(isDrawing)
+            TextEditor(text: $text)
+                .opacity(isDrawing ? 0 : 1)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { isDrawing.toggle() }) {
+                    Image(systemName: isDrawing ? "character.cursor.ibeam" : "pencil.tip")
+                }
+            }
+        }
+    }
+}
+
+struct CanvasRepresentable: UIViewRepresentable {
+    @Binding var canvasView: PKCanvasView
+
+    func makeUIView(context: Context) -> PKCanvasView {
+        canvasView.drawingPolicy = .pencilOnly
+        canvasView.allowsFingerDrawing = false
+        return canvasView
+    }
+
+    func updateUIView(_ uiView: PKCanvasView, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- define Core Data entities for notes, blocks, and strokes with a basic persistence stack
- add SwiftUI layered editor combining `PKCanvasView` and `TextEditor` with a toggle button
- implement stubbed services for saving drawings, indexing text with SQLite FTS5, and parsing a minimal PersonaUI DSL

## Testing
- `swiftc Sources/Model/*.swift Sources/Services/*.swift Sources/Views/*.swift Sources/PersonaUI/*.swift` *(fails: no such module 'CoreData')*

------
https://chatgpt.com/codex/tasks/task_e_68af84933e24832282a4092e734e7ddf