### PR TITLE
Add transformer for keyword arrays

### DIFF
--- a/Sources/Model/Note.swift
+++ b/Sources/Model/Note.swift
@@ -7,6 +7,7 @@ public class Note: NSManagedObject {
     @NSManaged public var title: String
     @NSManaged public var createdAt: Date
     @NSManaged public var updatedAt: Date
+    /// Array of keywords persisted using `StringArrayTransformer`.
     @NSManaged public var keywords: [String]?
     @NSManaged public var blocks: NSSet?
 }

--- a/Sources/Model/Persistence.swift
+++ b/Sources/Model/Persistence.swift
@@ -6,6 +6,7 @@ struct PersistenceController {
     let container: NSPersistentContainer
 
     init(inMemory: Bool = false) {
+        ValueTransformer.setValueTransformer(StringArrayTransformer(), forName: NSValueTransformerName("StringArrayTransformer"))
         container = NSPersistentContainer(name: "DoneIt")
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")

--- a/Sources/Model/StringArrayTransformer.swift
+++ b/Sources/Model/StringArrayTransformer.swift
@@ -1,0 +1,31 @@
+import Foundation
+import CoreData
+
+@objc(StringArrayTransformer)
+final class StringArrayTransformer: ValueTransformer {
+    override class func transformedValueClass() -> AnyClass {
+        return NSData.self
+    }
+
+    override class func allowsReverseTransformation() -> Bool {
+        return true
+    }
+
+    override func transformedValue(_ value: Any?) -> Any? {
+        guard let array = value as? [String] else { return nil }
+        do {
+            return try JSONEncoder().encode(array)
+        } catch {
+            return nil
+        }
+    }
+
+    override func reverseTransformedValue(_ value: Any?) -> Any? {
+        guard let data = value as? Data else { return nil }
+        do {
+            return try JSONDecoder().decode([String].self, from: data)
+        } catch {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `StringArrayTransformer` to encode/decode `[String]`
- register transformer during persistence controller setup
- document `Note.keywords` persistence using transformer

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1a51160832286b7736149ca6619