### PR TITLE
Add SQLite error handling to SearchIndex

### DIFF
--- a/Sources/Services/SearchIndex.swift
+++ b/Sources/Services/SearchIndex.swift
@@ -1,48 +1,81 @@
 import Foundation
 import SQLite3
 
+enum SearchIndexError: Error {
+    case open(String)
+    case execute(String)
+    case prepare(String)
+    case step(String)
+}
+
 final class SearchIndex {
     private var db: OpaquePointer?
 
-    init(path: URL) {
-        sqlite3_open(path.path, &db)
+    init(path: URL) throws {
+        if sqlite3_open(path.path, &db) != SQLITE_OK {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw SearchIndexError.open(message)
+        }
         let createSQL = """
         CREATE VIRTUAL TABLE IF NOT EXISTS notes USING fts5(id, title, text, keywords);
         """
-        sqlite3_exec(db, createSQL, nil, nil, nil)
+        if sqlite3_exec(db, createSQL, nil, nil, nil) != SQLITE_OK {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw SearchIndexError.execute(message)
+        }
     }
 
     deinit {
-        sqlite3_close(db)
+        if sqlite3_close(db) != SQLITE_OK {
+            print("SQLite close error: \(String(cString: sqlite3_errmsg(db)))")
+        }
     }
 
-    func index(note: Note) {
+    func index(note: Note) throws {
         let insertSQL = "INSERT INTO notes (id, title, text, keywords) VALUES (?, ?, ?, ?);"
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK {
-            sqlite3_bind_text(stmt, 1, note.id.uuidString, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_text(stmt, 2, note.title, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_text(stmt, 3, note.blockTexts(), -1, SQLITE_TRANSIENT)
-            let keywords = note.keywords?.joined(separator: " ") ?? ""
-            sqlite3_bind_text(stmt, 4, keywords, -1, SQLITE_TRANSIENT)
-            sqlite3_step(stmt)
+        guard sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw SearchIndexError.prepare(message)
         }
-        sqlite3_finalize(stmt)
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, note.id.uuidString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, note.title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, note.blockTexts(), -1, SQLITE_TRANSIENT)
+        let keywords = note.keywords?.joined(separator: " ") ?? ""
+        sqlite3_bind_text(stmt, 4, keywords, -1, SQLITE_TRANSIENT)
+
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw SearchIndexError.step(message)
+        }
     }
 
-    func search(_ query: String) -> [String] {
+    func search(_ query: String) throws -> [String] {
         var results: [String] = []
         let searchSQL = "SELECT snippet(notes, 2, '[', ']', '…', 10) FROM notes WHERE notes MATCH ?;"
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, searchSQL, -1, &stmt, nil) == SQLITE_OK {
-            sqlite3_bind_text(stmt, 1, query, -1, SQLITE_TRANSIENT)
-            while sqlite3_step(stmt) == SQLITE_ROW {
+        guard sqlite3_prepare_v2(db, searchSQL, -1, &stmt, nil) == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw SearchIndexError.prepare(message)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, query, -1, SQLITE_TRANSIENT)
+        while true {
+            let rc = sqlite3_step(stmt)
+            if rc == SQLITE_ROW {
                 if let cString = sqlite3_column_text(stmt, 0) {
                     results.append(String(cString: cString))
                 }
+            } else if rc == SQLITE_DONE {
+                break
+            } else {
+                let message = String(cString: sqlite3_errmsg(db))
+                throw SearchIndexError.step(message)
             }
         }
-        sqlite3_finalize(stmt)
         return results
     }
 }


### PR DESCRIPTION
## Summary
- check SQLite return codes when opening DB and running queries
- propagate SQLite errors via SearchIndexError

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swiftc -typecheck Sources/Services/SearchIndex.swift` *(fails: no such module 'SQLite3')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1a333808322af7d405398aadb8c